### PR TITLE
Fix missing unix socket usage in DatabaseConnectionInformation

### DIFF
--- a/Install/src/app.php
+++ b/Install/src/app.php
@@ -279,6 +279,7 @@ $app->any('/database-configuration/', function (ServerRequestInterface $request,
     $connectionInfo->port = $databaseParameters['port'];
     $connectionInfo->databaseName = $databaseParameters['database'];
     $connectionInfo->password = $databaseParameters['password'];
+    $connectionInfo->socket = $databaseParameters['socket'];
 
     try {
         try {


### PR DESCRIPTION
We tried to install Shopware 6 on Google Cloud Run with Google Cloud SQL.
The default Google Cloud SQL Proxy runs over UNIX Socket.

But the installation doesn't add the socket to the DatabaseConnectionInformation.
So the Factory can't create the correct connection.